### PR TITLE
[Core] Add support older version of django.

### DIFF
--- a/django_cprofile_middleware/middleware.py
+++ b/django_cprofile_middleware/middleware.py
@@ -9,9 +9,14 @@ try:
 except:
     from io import StringIO
 
+import django
 from django.conf import settings
 from django.http import HttpResponse
-from django.utils.deprecation import MiddlewareMixin
+
+if django.VERSION >= (1, 10):
+    from django.utils.deprecation import MiddlewareMixin
+else:
+    from django_cprofile_middleware.utils import MiddlewareMixin
 
 
 class ProfilerMiddleware(MiddlewareMixin):

--- a/django_cprofile_middleware/utils.py
+++ b/django_cprofile_middleware/utils.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+"""This module contain utils class"""
+
+
+class MiddlewareMixin(object):
+    """A dummy class to support older version of django."""
+    pass


### PR DESCRIPTION
The mixin MiddlewareMixin come with django 1.10. Add a dummy class to
support older version of django.

Fixes: #15