### PR TITLE
Removes is_staff requirement for middleware

### DIFF
--- a/django_cprofile_middleware/middleware.py
+++ b/django_cprofile_middleware/middleware.py
@@ -41,6 +41,11 @@ class ProfilerMiddleware(MiddlewareMixin):
     http://www.slideshare.net/zeeg/django-con-high-performance-django-presentation.
     """
     def can(self, request):
+        requires_staff = getattr(settings, "DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF", True):
+
+        if requires_staff and not (request.user and request.user.is_staff):
+            return False
+
         return settings.DEBUG and 'prof' in request.GET
 
     def process_view(self, request, callback, callback_args, callback_kwargs):

--- a/django_cprofile_middleware/middleware.py
+++ b/django_cprofile_middleware/middleware.py
@@ -41,8 +41,7 @@ class ProfilerMiddleware(MiddlewareMixin):
     http://www.slideshare.net/zeeg/django-con-high-performance-django-presentation.
     """
     def can(self, request):
-        return settings.DEBUG and 'prof' in request.GET and \
-            request.user is not None and request.user.is_staff
+        return settings.DEBUG and 'prof' in request.GET
 
     def process_view(self, request, callback, callback_args, callback_kwargs):
         if self.can(request):


### PR DESCRIPTION
I am trying to profile a particular page from the viewpoint of a non-staff user in my application, which I can't do using this middleware as it currently exists.  

I understand that adding the `is_staff==True` restriction adds an additional layer of security around revealing the profiler output, but there are cases where the code path is different for staff and non-staff users and there is a bottleneck in the non-staff case.  Especially since DEBUG is already a requirement, I think that it is reasonable to assume that this middleware should never be used in production anyway.