### PR TITLE
Fixes a syntax error. Adds tests.

### DIFF
--- a/django_cprofile_middleware/middleware.py
+++ b/django_cprofile_middleware/middleware.py
@@ -29,7 +29,8 @@ class ProfilerMiddleware(MiddlewareMixin):
     Optionally pass the following to modify the output:
 
     ?sort => Sort the output by a given metric. Default is time.
-        See http://docs.python.org/2/library/profile.html#pstats.Stats.sort_stats
+        See
+        http://docs.python.org/2/library/profile.html#pstats.Stats.sort_stats
         for all sort options.
 
     ?count => The number of rows to display. Default is 100.
@@ -41,7 +42,8 @@ class ProfilerMiddleware(MiddlewareMixin):
     http://www.slideshare.net/zeeg/django-con-high-performance-django-presentation.
     """
     def can(self, request):
-        requires_staff = getattr(settings, "DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF", True):
+        requires_staff = getattr(
+            settings, "DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF", True)
 
         if requires_staff and not (request.user and request.user.is_staff):
             return False

--- a/django_cprofile_middleware/test_middleware.py
+++ b/django_cprofile_middleware/test_middleware.py
@@ -1,0 +1,99 @@
+import unittest
+from unittest import mock
+
+from django.conf import settings
+from django import http
+from django import test
+from django import views
+from django.test import client
+
+from django_cprofile_middleware import middleware
+
+settings.configure()
+
+
+class MiddlewareTest(unittest.TestCase):
+
+    class SampleView(views.View):
+
+        def get(self, request):
+            return http.HttpResponse()
+
+    def setUp(self):
+        self.view = MiddlewareTest.SampleView()
+        self.middleware = middleware.ProfilerMiddleware()
+        self.request = client.RequestFactory().get('/sample/?prof')
+        self.default_response = http.HttpResponse('default response')
+        self.override_settings = {
+            'DEBUG': True,
+            'DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF': False}
+        self.profile_content = '<pre>'.encode('utf-8')
+
+    def test_profile(self):
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                self.request, self.view.get, (self.request,), {})
+            response = self.middleware.process_response(
+                self.request, self.default_response)
+        self.assertTrue(response.content.startswith(self.profile_content))
+        self.assertIn('function calls'.encode('utf-8'), response.content)
+        self.assertEqual(response['Content-Type'], 'text/html; charset=utf-8')
+
+    def test_download_profile(self):
+        request = client.RequestFactory().get('/sample/?prof&download')
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                request, self.view.get, (request,), {})
+            response = self.middleware.process_response(
+                request, self.default_response)
+        self.assertEqual(response['Content-Type'], 'application/octet-stream')
+
+    def test_get_param_required(self):
+        request = client.RequestFactory().get('/sample/')
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                request, self.view.get, (request,), {})
+            response = self.middleware.process_response(
+                request, self.default_response)
+        self.assertEqual(response.content, self.default_response.content)
+
+    def test_debug_required(self):
+        self.override_settings['DEBUG'] = False
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                self.request, self.view.get, (self.request,), {})
+            response = self.middleware.process_response(
+                self.request, self.default_response)
+        self.assertEqual(response.content, self.default_response.content)
+
+    def test_staff_setting_no_user(self):
+        self.override_settings[
+            'DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF'] = True
+        with test.override_settings(**self.override_settings):
+            with self.assertRaises(AttributeError):
+                self.middleware.process_view(
+                    self.request, self.view.get, (self.request,), {})
+                self.middleware.process_response(
+                    self.request, self.default_response)
+
+    def test_staff_setting_non_staff_user(self):
+        self.override_settings[
+            'DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF'] = True
+        self.request.user = mock.MagicMock(is_staff=False)
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                self.request, self.view.get, (self.request,), {})
+            response = self.middleware.process_response(
+                self.request, self.default_response)
+        self.assertEqual(response.content, self.default_response.content)
+
+    def test_staff_setting_staff_user(self):
+        self.override_settings[
+            'DJANGO_CPROFILE_MIDDLEWARE_REQUIRE_STAFF'] = True
+        self.request.user = mock.MagicMock(is_staff=True)
+        with test.override_settings(**self.override_settings):
+            self.middleware.process_view(
+                self.request, self.view.get, (self.request,), {})
+            response = self.middleware.process_response(
+                self.request, self.default_response)
+        self.assertTrue(response.content.startswith(self.profile_content))


### PR DESCRIPTION
Extra colon in middleware.py line 44.

Tests can be run from the repo root with:
python -m unittest

Tests require django be installed. They just
call the middleware directly.